### PR TITLE
Improve console feedback and simplify logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,20 +1,20 @@
 # main.py
 import os
 import argparse
+from rich.console import Console
 import merger as m
 import miscutil as mu
 import checks
 import config as cfg
 
+console = Console()
+
 def display_title_bar():
-    title_bar = """
-    ╭──────────────────────────────────────────────╮
-    │                   DWGMAGIC                   │
-    ├──────────────────────────────────────────────┤
-    │        TECTONICA - Dimitar Baldzhiev         │
-    ╰──────────────────────────────────────────────╯
-    """
-    print(title_bar)
+    console.print("╭──────────────────────────────────────────────╮", style="cyan")
+    console.print("│                   [bold magenta]DWGMAGIC[/bold magenta]                   │")
+    console.print("├──────────────────────────────────────────────┤", style="cyan")
+    console.print("│        [italic]TECTONICA - Dimitar Baldzhiev[/italic]         │")
+    console.print("╰──────────────────────────────────────────────╯", style="cyan")
 
 def parse_args():
     parser = argparse.ArgumentParser(description="DWGMAGIC Toolset")

--- a/miscutil.py
+++ b/miscutil.py
@@ -50,6 +50,13 @@ def create_directory(path):
             else:
                 print(f"Failed to create {path}: {exc}")
 
+def cleanup_old_logs(log_dir):
+    """Rename existing log directory and create a fresh one."""
+    if os.path.exists(log_dir):
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        os.rename(log_dir, f"{log_dir}_backup_{timestamp}")
+    create_directory(log_dir)
+
 def preprocess():
     global logger
     base_path = os.getcwd()
@@ -57,8 +64,9 @@ def preprocess():
     logger = setup_logger("MISC_UTIL")
     logger.info("Starting preprocessing")
     dwg_files = get_dwg_files_in_directory(base_path)
-    for folder in ["scripts", "originals", "derevitized", "logs"]:
+    for folder in ["scripts", "originals", "derevitized"]:
         create_directory(os.path.join(base_path, folder))
+    cleanup_old_logs(os.path.join(base_path, "logs"))
     
     logger.info("COPYING %d FILES", len(dwg_files))
     for file_name in dwg_files:

--- a/script_generator.py
+++ b/script_generator.py
@@ -11,8 +11,9 @@ env = Environment(
     lstrip_blocks=True
 )
 
-def setup_script_logger(log_dir=None):
-    log_dir = log_dir or os.path.join(cfg.DMM_PATH, "logs")
+def setup_script_logger():
+    """Create and return a logger for script generation."""
+    log_dir = os.path.join(os.getcwd(), "logs")
     return setup_logger("SCRIPT_GENERATOR", log_dir=log_dir)
 
 def generate_script(template_name, output_path, logger, **context):
@@ -22,8 +23,8 @@ def generate_script(template_name, output_path, logger, **context):
         script_file.write(script_content)
     logger.info("Generated script %s", output_path)
 
-def generate_project_script(sheet_names_list, xref_xplode_toggle, sheets, log_dir=None):
-    logger = setup_script_logger(log_dir)
+def generate_project_script(sheet_names_list, xref_xplode_toggle, sheets):
+    logger = setup_script_logger()
     generate_script('./templates/project_script_template.tmpl', './scripts/DWGMAGIC.scr', logger,
                     sheetNamesList=sheet_names_list,
                     tectonica_path=cfg.DMM_PATH,
@@ -31,28 +32,28 @@ def generate_project_script(sheet_names_list, xref_xplode_toggle, sheets, log_di
                     xrefXplodeToggle=xref_xplode_toggle,
                     sheets=sheets)
 
-def generate_manual_master_merge_script(xref_xplode_toggle, sheets, log_dir=None):
-    logger = setup_script_logger(log_dir)
+def generate_manual_master_merge_script(xref_xplode_toggle, sheets):
+    logger = setup_script_logger()
     generate_script('./templates/mmm_script_template.tmpl', './scripts/MMM.scr', logger,
                     tectonica_path=cfg.DMM_PATH,
                     xrefXplodeToggle=xref_xplode_toggle,
                     sheets=sheets,
                     project_name=os.path.basename(os.getcwd()))
 
-def generate_manual_master_merge_bat(accpath, log_dir=None):
-    logger = setup_script_logger(log_dir)
+def generate_manual_master_merge_bat(accpath):
+    logger = setup_script_logger()
     generate_script('./templates/manual_merge_bat_template.tmpl', './MANUALMERGE.bat', logger,
                     acc=accpath,
                     project_name=os.path.basename(os.getcwd()))
 
-def generate_sheet_script(sheet_name, views_on_sheet,sheet_cleaner_script, log_dir=None):
-    logger = setup_script_logger(log_dir)
+def generate_sheet_script(sheet_name, views_on_sheet,sheet_cleaner_script):
+    logger = setup_script_logger()
     generate_script('./templates/sheet_script_template.tmpl', f'./scripts/{sheet_cleaner_script}', logger,
                     viewsOnSheet=views_on_sheet,
                     tectonica_path=cfg.DMM_PATH,
                     sheetName=sheet_name)
 
-def generate_view_script(view_name,view_cleaner_script, log_dir=None):
-    logger = setup_script_logger(log_dir)
+def generate_view_script(view_name,view_cleaner_script):
+    logger = setup_script_logger()
     generate_script('./templates/view_script_template.tmpl', f'./scripts/{view_cleaner_script}', logger,
                     viewName=view_name)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -33,8 +33,8 @@ class TestChecks(unittest.TestCase):
         mock_popen.return_value = process_mock
 
         # First run, no error in output
-        ck.checks(log_dir="logs")
-        mock_setup_logger.assert_called_with("CHECKS", log_dir="logs")
+        ck.checks()
+        mock_setup_logger.assert_called_with("CHECKS")
         mock_logger.info.assert_any_call("ACCORECONSOLE PATH: %s", "/path/to/acc")
         mock_popen.assert_called()
         mock_exit.assert_not_called()
@@ -42,7 +42,7 @@ class TestChecks(unittest.TestCase):
         # Second run, error in output
         process_mock.communicate.return_value = ("Unable to load C:\\dwgmagic\\tectonica.dll assembly.", None)
         try:
-            ck.checks(log_dir="logs")
+            ck.checks()
         except SystemExit:
             pass  # Expected exit
 

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -37,9 +37,9 @@ class TestMerger(unittest.TestCase):
         mock_setup_logger.return_value = mock_logger
         mock_run_command.return_value = ("output", None)
         
-        merger.view_worker("test.dwg", "/path/to/acc", "/path/to/logs")
-        mock_generate_view_script.assert_called_with("test", "TEST.scr", log_dir="/path/to/logs")
-        mock_setup_logger.assert_called_with("TEST", log_dir="/path/to/logs")
+        merger.view_worker("test.dwg", "/path/to/acc")
+        mock_generate_view_script.assert_called_with("test", "TEST.scr")
+        mock_setup_logger.assert_called_with("TEST")
         mock_run_command.assert_called()
         
     @patch('merger.sg.generate_sheet_script')
@@ -51,9 +51,9 @@ class TestMerger(unittest.TestCase):
         mock_setup_logger.return_value = mock_logger
         mock_run_command.return_value = ("output", None)
         
-        merger.sheet_worker("test.dwg", "/path/to/acc", "/path/to/logs", ["test-View-1.dwg"])
-        mock_generate_sheet_script.assert_called_with("test", ["test-View-1.dwg"], "TEST_SHEET.scr", log_dir="/path/to/logs")
-        mock_setup_logger.assert_called_with("SHEET_test", log_dir="/path/to/logs")
+        merger.sheet_worker("test.dwg", "/path/to/acc", ["test-View-1.dwg"])
+        mock_generate_sheet_script.assert_called_with("test", ["test-View-1.dwg"], "TEST_SHEET.scr")
+        mock_setup_logger.assert_called_with("SHEET_test")
         mock_run_command.assert_called()
         mock_remove.assert_called_with(f"{os.getcwd()}/derevitized/test.dwg")
 

--- a/tests/test_scriptgenerator.py
+++ b/tests/test_scriptgenerator.py
@@ -17,13 +17,13 @@ class TestScriptGenerator(unittest.TestCase):
 
         with patch('builtins.open', mock_open()) as mocked_file:
             sg.generate_script('template.tmpl', '/path/to/output', logger, context_key='value')
-            mocked_file.assert_called_with('/path/to/output', 'w')
+            mocked_file.assert_called_with('/path/to/output', 'w', encoding='utf-8')
             mocked_file().write.assert_called_with('rendered content')
             logger.info.assert_called_with("Generated script %s", '/path/to/output')
 
     @patch('script_generator.generate_script')
     def test_generate_project_script(self, mock_generate_script):
-        sg.generate_project_script(['sheet1', 'sheet2'], True, ['sheet'], log_dir='logs')
+        sg.generate_project_script(['sheet1', 'sheet2'], True, ['sheet'])
         mock_generate_script.assert_called_with(
             './templates/project_script_template.tmpl', './scripts/DWGMAGIC.scr', 
             mock.ANY,
@@ -36,7 +36,7 @@ class TestScriptGenerator(unittest.TestCase):
 
     @patch('script_generator.generate_script')
     def test_generate_manual_master_merge_script(self, mock_generate_script):
-        sg.generate_manual_master_merge_script(True, ['sheet'], log_dir='logs')
+        sg.generate_manual_master_merge_script(True, ['sheet'])
         mock_generate_script.assert_called_with(
             './templates/mmm_script_template.tmpl', './scripts/MMM.scr', 
             mock.ANY,
@@ -48,7 +48,7 @@ class TestScriptGenerator(unittest.TestCase):
 
     @patch('script_generator.generate_script')
     def test_generate_manual_master_merge_bat(self, mock_generate_script):
-        sg.generate_manual_master_merge_bat('/path/to/acc', log_dir='logs')
+        sg.generate_manual_master_merge_bat('/path/to/acc')
         mock_generate_script.assert_called_with(
             './templates/manual_merge_bat_template.tmpl', './MANUALMERGE.bat', 
             mock.ANY,


### PR DESCRIPTION
## Summary
- enhance console visual feedback using `rich` in `main.py`
- default logging paths and remove log_dir option
- update workers and project to use default log directory
- add utility for rotating log folders
- update tests for new logging behaviour

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5f52ff0c832a93eeb98d7b6a01f0