### PR TITLE
Move log cleanup before logger initialization

### DIFF
--- a/miscutil.py
+++ b/miscutil.py
@@ -61,12 +61,12 @@ def preprocess():
     global logger
     base_path = os.getcwd()
     remove_previous_preprocess(base_path)
+    cleanup_old_logs(os.path.join(base_path, "logs"))
     logger = setup_logger("MISC_UTIL")
     logger.info("Starting preprocessing")
     dwg_files = get_dwg_files_in_directory(base_path)
     for folder in ["scripts", "originals", "derevitized"]:
         create_directory(os.path.join(base_path, folder))
-    cleanup_old_logs(os.path.join(base_path, "logs"))
     
     logger.info("COPYING %d FILES", len(dwg_files))
     for file_name in dwg_files:


### PR DESCRIPTION
## Summary
- move the log cleanup step ahead of logger initialization to avoid renaming an in-use log directory

## Testing
- python -m pytest *(fails: script generator writes cp1251 rather than expected utf-8)*

------
https://chatgpt.com/codex/tasks/task_e_69086ae07f3c832aaa22e27331c616d8