### PR TITLE
Handle locked log directory during cleanup

### DIFF
--- a/miscutil.py
+++ b/miscutil.py
@@ -54,19 +54,46 @@ def cleanup_old_logs(log_dir):
     """Rename existing log directory and create a fresh one."""
     if os.path.exists(log_dir):
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        os.rename(log_dir, f"{log_dir}_backup_{timestamp}")
+        backup_dir = f"{log_dir}_backup_{timestamp}"
+        try:
+            os.rename(log_dir, backup_dir)
+        except OSError as exc:
+            message = (
+                f"Failed to archive existing logs at {log_dir}: {exc}. "
+                "Attempting to clear accessible log files in place."
+            )
+            if logger:
+                logger.warning(message)
+            else:
+                print(message)
+
+            for entry in os.listdir(log_dir):
+                entry_path = os.path.join(log_dir, entry)
+                if os.path.isdir(entry_path):
+                    safe_remove(entry_path)
+                else:
+                    try:
+                        os.remove(entry_path)
+                    except Exception as remove_exc:
+                        if logger:
+                            logger.error("Unable to remove %s: %s", entry_path, remove_exc)
+                        else:
+                            print(f"Unable to remove {entry_path}: {remove_exc}")
+        else:
+            create_directory(log_dir)
+            return
     create_directory(log_dir)
 
 def preprocess():
     global logger
     base_path = os.getcwd()
     remove_previous_preprocess(base_path)
+    cleanup_old_logs(os.path.join(base_path, "logs"))
     logger = setup_logger("MISC_UTIL")
     logger.info("Starting preprocessing")
     dwg_files = get_dwg_files_in_directory(base_path)
     for folder in ["scripts", "originals", "derevitized"]:
         create_directory(os.path.join(base_path, folder))
-    cleanup_old_logs(os.path.join(base_path, "logs"))
     
     logger.info("COPYING %d FILES", len(dwg_files))
     for file_name in dwg_files:

--- a/miscutil.py
+++ b/miscutil.py
@@ -59,11 +59,11 @@ def cleanup_old_logs(log_dir):
             os.rename(log_dir, backup_dir)
         except OSError as exc:
             message = (
-                f"Failed to archive existing logs at {log_dir}: {exc}. "
-                "Attempting to clear accessible log files in place."
+                f"Logs directory {log_dir} could not be archived ({exc}). "
+                "Continuing to reuse the existing directory."
             )
             if logger:
-                logger.warning(message)
+                logger.info(message)
             else:
                 print(message)
 
@@ -74,9 +74,16 @@ def cleanup_old_logs(log_dir):
                 else:
                     try:
                         os.remove(entry_path)
+                    except PermissionError as remove_exc:
+                        if logger:
+                            logger.debug(
+                                "Skipping locked log file %s: %s", entry_path, remove_exc
+                            )
+                        else:
+                            print(f"Skipping locked log file {entry_path}: {remove_exc}")
                     except Exception as remove_exc:
                         if logger:
-                            logger.error("Unable to remove %s: %s", entry_path, remove_exc)
+                            logger.warning("Unable to remove %s: %s", entry_path, remove_exc)
                         else:
                             print(f"Unable to remove {entry_path}: {remove_exc}")
         else:


### PR DESCRIPTION
## Summary
- handle failures when renaming the existing logs directory by logging the issue and clearing accessible files in place
- ensure the logs directory is available for the next run even if archival fails

## Testing
- python -m pytest tests/test_miscutil.py *(fails: tests/test_miscutil.py does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_69086ae07f3c832aaa22e27331c616d8