### PR TITLE
Add DWG archive restoration and backup

### DIFF
--- a/dwgmagic/miscutil.py
+++ b/dwgmagic/miscutil.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import shutil
+import zipfile
 from datetime import datetime
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +17,7 @@ class Preprocessor:
 
     def preprocess(self, context: ProjectContext, logger) -> List[str]:
         project_root = context.project_root
+        self._restore_from_archive(project_root, logger)
         dwg_files, from_originals = self._collect_dwg_files(project_root)
         if not dwg_files:
             raise RuntimeError("No DWG files found in project root")
@@ -29,6 +31,7 @@ class Preprocessor:
                 for entry in project_root.iterdir()
                 if entry.suffix.lower() == ".dwg" and entry.is_file()
             )
+            self._create_archive_backup(project_root, dwg_files, logger)
 
         self._cleanup_logs(project_root / context.settings.log_dir, logger)
         self._ensure_directories(project_root, ("scripts", "originals", "derevitized"))
@@ -79,6 +82,39 @@ class Preprocessor:
                         shutil.rmtree(target, ignore_errors=True)
                     else:
                         target.unlink(missing_ok=True)
+
+    def _restore_from_archive(self, root: Path, logger) -> None:
+        archive = root / "original.zip"
+        if not archive.exists():
+            return
+
+        logger.info("Restoring project from archive %s", archive)
+        for entry in root.iterdir():
+            if entry == archive:
+                continue
+            if entry.is_dir():
+                shutil.rmtree(entry, ignore_errors=True)
+            else:
+                entry.unlink(missing_ok=True)
+
+        with zipfile.ZipFile(archive, "r") as zip_file:
+            zip_file.extractall(root)
+
+    def _create_archive_backup(
+        self, root: Path, files: Sequence[Path], logger
+    ) -> None:
+        if not files:
+            return
+
+        archive = root / "original.zip"
+        try:
+            with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+                for path in files:
+                    zip_file.write(path, arcname=path.name)
+        except OSError as exc:  # pragma: no cover - disk issues are environment-specific
+            logger.warning("Unable to create archive %s: %s", archive, exc)
+        else:
+            logger.info("Created archive backup %s with %d files", archive, len(files))
 
     def _restore_project_root(
         self, root: Path, originals: Sequence[Path], logger

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,3 +1,4 @@
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -56,6 +57,10 @@ def test_preprocessor_stage(tmp_path):
     assert context.get("dwg_files") == ["example.dwg"]
     assert (tmp_path / "derevitized" / "example.dwg").exists()
     assert (tmp_path / "originals" / "example.dwg").exists()
+    archive = tmp_path / "original.zip"
+    assert archive.exists()
+    with zipfile.ZipFile(archive) as zip_file:
+        assert sorted(zip_file.namelist()) == ["example.dwg"]
 
 
 def test_preprocessor_stage_reruns_from_originals(tmp_path):
@@ -86,6 +91,29 @@ def test_preprocessor_stage_reruns_from_originals(tmp_path):
     assert not (scripts_dir / "old.scr").exists()
     assert not stale_root.exists()
     assert not (tmp_path / "rerun.dwg").exists()
+
+
+def test_preprocessor_stage_uses_archive_when_present(tmp_path):
+    context, settings = make_context(tmp_path)
+    archive = tmp_path / "original.zip"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("archived.dwg", "archived")
+
+    stray = tmp_path / "stray.txt"
+    stray.write_text("obsolete")
+
+    stage = PreprocessorStage(Preprocessor(), LoggerFactory(settings))
+    result = stage.run(context)
+
+    assert result.succeeded is True
+    assert context.get("dwg_files") == ["archived.dwg"]
+    assert (tmp_path / "derevitized" / "archived.dwg").exists()
+    assert (tmp_path / "originals" / "archived.dwg").exists()
+    assert not (tmp_path / "archived.dwg").exists()
+    assert not stray.exists()
+
+    with zipfile.ZipFile(archive) as zip_file:
+        assert sorted(zip_file.namelist()) == ["archived.dwg"]
 
 
 def test_script_generation_stage(tmp_path):


### PR DESCRIPTION
## Summary
- restore project contents from original.zip when present, clearing other files
- create original.zip backups during preprocessing for DWG sources
- extend preprocessing tests to cover archive scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69090d499210832aac047fd48d500438