### PR TITLE
Improve installer resilience for robocopy failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The modernised architecture replaces historical global state with an explicit pi
 
 ### Windows desktop integration
 The repository now ships with helper scripts that set up shortcuts and shell integration for a smoother workflow on Windows:
-1. Run `install.bat` to copy the project into `%LOCALAPPDATA%\dwgmagic`, register a **Run with DWGMAGIC** context-menu entry for directories, and create a desktop shortcut that launches the GUI (`run_gui.bat`).
+1. Run `install.bat` to copy the project into `%LOCALAPPDATA%\dwgmagic`, register a **Run with DWGMAGIC** context-menu entry for directories, and create a desktop shortcut that launches the GUI (`run_gui.bat`). If `robocopy` encounters a critical error (for example, exit code 16), the installer now prints the captured log and automatically retries the copy by using PowerShell so that the installation can still complete.
 2. After installation you can either double-click the desktop shortcut for the GUI or right-click any project directory and choose **Run with DWGMAGIC** to execute the CLI pipeline via `run_context_menu.bat`.
 3. To remove the integration, run `uninstall.bat`. This removes the context-menu entry, deletes the desktop shortcut, and wipes the installed copy under `%LOCALAPPDATA%\dwgmagic`.
 

--- a/install.bat
+++ b/install.bat
@@ -10,6 +10,7 @@ set "INSTALL_DIR=%LOCALAPPDATA%\dwgmagic"
 set "SOURCE_DIR=%~dp0"
 set "SHORTCUT_NAME=%APP_NAME% GUI.lnk"
 set "CONTEXT_KEY=Software\Classes\Directory\shell\DWGMAGIC"
+set "ROBO_LOG=%TEMP%\dwgmagic_robocopy.log"
 
 echo Installing %APP_NAME% to "%INSTALL_DIR%"...
 if not exist "%INSTALL_DIR%" (
@@ -20,17 +21,35 @@ if not exist "%INSTALL_DIR%" (
 )
 
 echo Copying application files...
-robocopy "%SOURCE_DIR%" "%INSTALL_DIR%" /MIR /R:2 /W:5 /XD ".git" ".mypy_cache" ".pytest_cache" "__pycache__" >nul
+robocopy "%SOURCE_DIR%" "%INSTALL_DIR%" /MIR /R:2 /W:5 /XD ".git" ".mypy_cache" ".pytest_cache" "__pycache__" /NFL /NDL /NJH /NJS /LOG:"%ROBO_LOG%"
 set "ROBOCOPY_EXIT=%ERRORLEVEL%"
-if %ROBOCOPY_EXIT% GEQ 8 (
-    echo ERROR: File copy failed with code %ROBOCOPY_EXIT%.
-    exit /b %ROBOCOPY_EXIT%
+if %ROBOCOPY_EXIT% LSS 8 (
+    echo Files copied successfully.
+) else (
+    echo WARNING: Robocopy failed with code %ROBOCOPY_EXIT%.
+    if exist "%ROBO_LOG%" (
+        echo --- Robocopy output ---
+        type "%ROBO_LOG%"
+        echo --- End robocopy output ---
+    )
+    echo Attempting PowerShell fallback copy...
+    powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+        "param([string]$src,[string]$dest); $ErrorActionPreference='Stop'; $excludes = @('.git','.mypy_cache','.pytest_cache','__pycache__'); if (-not (Test-Path -LiteralPath $dest)) { New-Item -ItemType Directory -Path $dest -Force | Out-Null }; Get-ChildItem -LiteralPath $dest -Force | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue; Get-ChildItem -LiteralPath $src -Force | Where-Object { $excludes -notcontains $_.Name } | ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force }" ^
+        "%SOURCE_DIR%" "%INSTALL_DIR%"
+    if errorlevel 1 (
+        echo ERROR: Fallback copy failed.
+        if exist "%ROBO_LOG%" del "%ROBO_LOG%"
+        exit /b %ROBOCOPY_EXIT%
+    ) else (
+        echo Fallback copy succeeded.
+    )
 )
+if exist "%ROBO_LOG%" del "%ROBO_LOG%"
 
 echo Creating context menu entry...
 reg add "HKCU\%CONTEXT_KEY%" /ve /d "Run with DWGMAGIC" /f >nul
 reg add "HKCU\%CONTEXT_KEY%" /v "Icon" /d "\"%INSTALL_DIR%\\magic.ico\"" /f >nul
-reg add "HKCU\%CONTEXT_KEY%\\command" /ve /d "\"%INSTALL_DIR%\\run_context_menu.bat\" \"%%1\"" /f >nul
+reg add "HKCU\%CONTEXT_KEY%\command" /ve /d "\"%INSTALL_DIR%\\run_context_menu.bat\" \"%%1\"" /f >nul
 
 if exist "%INSTALL_DIR%\magic.ico" (
     set "SHORTCUT_ICON=%INSTALL_DIR%\magic.ico"

--- a/install.bat
+++ b/install.bat
@@ -8,6 +8,8 @@ if "%LOCALAPPDATA%"=="" (
 set "APP_NAME=DWGMAGIC"
 set "INSTALL_DIR=%LOCALAPPDATA%\dwgmagic"
 set "SOURCE_DIR=%~dp0"
+REM Ensure the source path remains safe to quote when copying the project files.
+if "%SOURCE_DIR:~-1%"=="\" set "SOURCE_DIR=%SOURCE_DIR%."
 set "SHORTCUT_NAME=%APP_NAME% GUI.lnk"
 set "CONTEXT_KEY=Software\Classes\Directory\shell\DWGMAGIC"
 set "ROBO_LOG=%TEMP%\dwgmagic_robocopy.log"
@@ -34,7 +36,7 @@ if %ROBOCOPY_EXIT% LSS 8 (
     )
     echo Attempting PowerShell fallback copy...
     powershell -NoProfile -ExecutionPolicy Bypass -Command ^
-        "param([string]$src,[string]$dest); $ErrorActionPreference='Stop'; $excludes = @('.git','.mypy_cache','.pytest_cache','__pycache__'); if (-not (Test-Path -LiteralPath $dest)) { New-Item -ItemType Directory -Path $dest -Force | Out-Null }; Get-ChildItem -LiteralPath $dest -Force | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue; Get-ChildItem -LiteralPath $src -Force | Where-Object { $excludes -notcontains $_.Name } | ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $dest -Recurse -Force }" ^
+        "param([string]$src,[string]$dest); $ErrorActionPreference='Stop'; $excludes = @('.git','.mypy_cache','.pytest_cache','__pycache__'); $srcPath = (Resolve-Path -LiteralPath $src).ProviderPath; if (-not (Test-Path -LiteralPath $dest)) { New-Item -ItemType Directory -Path $dest -Force | Out-Null }; $destPath = (Resolve-Path -LiteralPath $dest).ProviderPath; Get-ChildItem -LiteralPath $destPath -Force | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue; Get-ChildItem -LiteralPath $srcPath -Force | Where-Object { $excludes -notcontains $_.Name } | ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $destPath -Recurse -Force }" ^
         "%SOURCE_DIR%" "%INSTALL_DIR%"
     if errorlevel 1 (
         echo ERROR: Fallback copy failed.


### PR DESCRIPTION
## Summary
- capture robocopy output during installation and fall back to a PowerShell copy when mirroring files fails
- document the new fallback behaviour in the README so Windows users know what to expect

## Testing
- not run (not applicable on this platform)


------
https://chatgpt.com/codex/tasks/task_e_690cdef4af74832a9518bcae1ca7b073