### PR TITLE
Improve GUI window resizing behavior

### DIFF
--- a/dwgmagic/gui/app.py
+++ b/dwgmagic/gui/app.py
@@ -93,8 +93,8 @@ class GuiApplication:
 
         self.root = tk.Tk()
         self.root.title("DWGMAGIC Pipeline Monitor")
-        self.root.geometry("1280x860")
-        self.root.resizable(False, False)
+        self.root.minsize(1280, 860)
+        self.root.resizable(True, True)
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
 
         self.status_var = tk.StringVar(value="Ready")
@@ -161,7 +161,7 @@ class GuiApplication:
         self.progress_bar.pack(fill=tk.X)
 
         table_frame = ttk.LabelFrame(self.root, text="Stages")
-        table_frame.pack(fill=tk.X, padx=12, pady=(0, 10))
+        table_frame.pack(fill=tk.BOTH, expand=True, padx=12, pady=(0, 10))
 
         stage_container = ttk.Frame(table_frame)
         stage_container.pack(fill=tk.BOTH, expand=True, padx=8, pady=6)


### PR DESCRIPTION
## Summary
- allow the main window to resize while keeping a sensible minimum size
- let the stages table frame expand so its contents grow with the window

## Testing
- not run (GUI requires a display for manual resizing)


------
https://chatgpt.com/codex/tasks/task_e_690ce59af86c832aa3f4cf047a333951